### PR TITLE
Block and Transaction support in WASM

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1769,7 +1769,7 @@ checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
 [[package]]
 name = "snarkvm"
 version = "0.9.0"
-source = "git+https://github.com/Entropy1729/snarkVM.git#2c4e282df46ed71c809fd4b49738fd78562354ac"
+source = "git+https://github.com/Entropy1729/snarkVM.git#dce9afde31341f382423ee41991dea748d8ad086"
 dependencies = [
  "anyhow",
  "clap",
@@ -1797,7 +1797,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-algorithms"
 version = "0.9.0"
-source = "git+https://github.com/Entropy1729/snarkVM.git#2c4e282df46ed71c809fd4b49738fd78562354ac"
+source = "git+https://github.com/Entropy1729/snarkVM.git#dce9afde31341f382423ee41991dea748d8ad086"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -1823,7 +1823,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit"
 version = "0.9.0"
-source = "git+https://github.com/Entropy1729/snarkVM.git#2c4e282df46ed71c809fd4b49738fd78562354ac"
+source = "git+https://github.com/Entropy1729/snarkVM.git#dce9afde31341f382423ee41991dea748d8ad086"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-algorithms",
@@ -1837,7 +1837,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-account"
 version = "0.9.0"
-source = "git+https://github.com/Entropy1729/snarkVM.git#2c4e282df46ed71c809fd4b49738fd78562354ac"
+source = "git+https://github.com/Entropy1729/snarkVM.git#dce9afde31341f382423ee41991dea748d8ad086"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-network",
@@ -1848,7 +1848,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-algorithms"
 version = "0.9.0"
-source = "git+https://github.com/Entropy1729/snarkVM.git#2c4e282df46ed71c809fd4b49738fd78562354ac"
+source = "git+https://github.com/Entropy1729/snarkVM.git#dce9afde31341f382423ee41991dea748d8ad086"
 dependencies = [
  "snarkvm-circuit-types",
  "snarkvm-console-algorithms",
@@ -1858,7 +1858,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-collections"
 version = "0.9.0"
-source = "git+https://github.com/Entropy1729/snarkVM.git#2c4e282df46ed71c809fd4b49738fd78562354ac"
+source = "git+https://github.com/Entropy1729/snarkVM.git#dce9afde31341f382423ee41991dea748d8ad086"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-types",
@@ -1868,7 +1868,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment"
 version = "0.9.0"
-source = "git+https://github.com/Entropy1729/snarkVM.git#2c4e282df46ed71c809fd4b49738fd78562354ac"
+source = "git+https://github.com/Entropy1729/snarkVM.git#dce9afde31341f382423ee41991dea748d8ad086"
 dependencies = [
  "indexmap",
  "itertools",
@@ -1886,12 +1886,12 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment-witness"
 version = "0.9.0"
-source = "git+https://github.com/Entropy1729/snarkVM.git#2c4e282df46ed71c809fd4b49738fd78562354ac"
+source = "git+https://github.com/Entropy1729/snarkVM.git#dce9afde31341f382423ee41991dea748d8ad086"
 
 [[package]]
 name = "snarkvm-circuit-network"
 version = "0.9.0"
-source = "git+https://github.com/Entropy1729/snarkVM.git#2c4e282df46ed71c809fd4b49738fd78562354ac"
+source = "git+https://github.com/Entropy1729/snarkVM.git#dce9afde31341f382423ee41991dea748d8ad086"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-collections",
@@ -1902,7 +1902,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-program"
 version = "0.9.0"
-source = "git+https://github.com/Entropy1729/snarkVM.git#2c4e282df46ed71c809fd4b49738fd78562354ac"
+source = "git+https://github.com/Entropy1729/snarkVM.git#dce9afde31341f382423ee41991dea748d8ad086"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-network",
@@ -1914,7 +1914,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types"
 version = "0.9.0"
-source = "git+https://github.com/Entropy1729/snarkVM.git#2c4e282df46ed71c809fd4b49738fd78562354ac"
+source = "git+https://github.com/Entropy1729/snarkVM.git#dce9afde31341f382423ee41991dea748d8ad086"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-address",
@@ -1929,7 +1929,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-address"
 version = "0.9.0"
-source = "git+https://github.com/Entropy1729/snarkVM.git#2c4e282df46ed71c809fd4b49738fd78562354ac"
+source = "git+https://github.com/Entropy1729/snarkVM.git#dce9afde31341f382423ee41991dea748d8ad086"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -1942,7 +1942,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-boolean"
 version = "0.9.0"
-source = "git+https://github.com/Entropy1729/snarkVM.git#2c4e282df46ed71c809fd4b49738fd78562354ac"
+source = "git+https://github.com/Entropy1729/snarkVM.git#dce9afde31341f382423ee41991dea748d8ad086"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-console-types-boolean",
@@ -1951,7 +1951,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-field"
 version = "0.9.0"
-source = "git+https://github.com/Entropy1729/snarkVM.git#2c4e282df46ed71c809fd4b49738fd78562354ac"
+source = "git+https://github.com/Entropy1729/snarkVM.git#dce9afde31341f382423ee41991dea748d8ad086"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -1961,7 +1961,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-group"
 version = "0.9.0"
-source = "git+https://github.com/Entropy1729/snarkVM.git#2c4e282df46ed71c809fd4b49738fd78562354ac"
+source = "git+https://github.com/Entropy1729/snarkVM.git#dce9afde31341f382423ee41991dea748d8ad086"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -1973,7 +1973,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-integers"
 version = "0.9.0"
-source = "git+https://github.com/Entropy1729/snarkVM.git#2c4e282df46ed71c809fd4b49738fd78562354ac"
+source = "git+https://github.com/Entropy1729/snarkVM.git#dce9afde31341f382423ee41991dea748d8ad086"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -1984,7 +1984,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-scalar"
 version = "0.9.0"
-source = "git+https://github.com/Entropy1729/snarkVM.git#2c4e282df46ed71c809fd4b49738fd78562354ac"
+source = "git+https://github.com/Entropy1729/snarkVM.git#dce9afde31341f382423ee41991dea748d8ad086"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -1995,7 +1995,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-string"
 version = "0.9.0"
-source = "git+https://github.com/Entropy1729/snarkVM.git#2c4e282df46ed71c809fd4b49738fd78562354ac"
+source = "git+https://github.com/Entropy1729/snarkVM.git#dce9afde31341f382423ee41991dea748d8ad086"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2007,7 +2007,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-compiler"
 version = "0.9.0"
-source = "git+https://github.com/Entropy1729/snarkVM.git#2c4e282df46ed71c809fd4b49738fd78562354ac"
+source = "git+https://github.com/Entropy1729/snarkVM.git#dce9afde31341f382423ee41991dea748d8ad086"
 dependencies = [
  "anyhow",
  "colored",
@@ -2033,7 +2033,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console"
 version = "0.9.0"
-source = "git+https://github.com/Entropy1729/snarkVM.git#2c4e282df46ed71c809fd4b49738fd78562354ac"
+source = "git+https://github.com/Entropy1729/snarkVM.git#dce9afde31341f382423ee41991dea748d8ad086"
 dependencies = [
  "snarkvm-console-account",
  "snarkvm-console-algorithms",
@@ -2046,7 +2046,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-account"
 version = "0.9.0"
-source = "git+https://github.com/Entropy1729/snarkVM.git#2c4e282df46ed71c809fd4b49738fd78562354ac"
+source = "git+https://github.com/Entropy1729/snarkVM.git#dce9afde31341f382423ee41991dea748d8ad086"
 dependencies = [
  "bs58",
  "snarkvm-console-network",
@@ -2056,7 +2056,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-algorithms"
 version = "0.9.0"
-source = "git+https://github.com/Entropy1729/snarkVM.git#2c4e282df46ed71c809fd4b49738fd78562354ac"
+source = "git+https://github.com/Entropy1729/snarkVM.git#dce9afde31341f382423ee41991dea748d8ad086"
 dependencies = [
  "blake2s_simd",
  "smallvec",
@@ -2068,7 +2068,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-collections"
 version = "0.9.0"
-source = "git+https://github.com/Entropy1729/snarkVM.git#2c4e282df46ed71c809fd4b49738fd78562354ac"
+source = "git+https://github.com/Entropy1729/snarkVM.git#dce9afde31341f382423ee41991dea748d8ad086"
 dependencies = [
  "aleo-std",
  "rayon",
@@ -2079,7 +2079,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network"
 version = "0.9.0"
-source = "git+https://github.com/Entropy1729/snarkVM.git#2c4e282df46ed71c809fd4b49738fd78562354ac"
+source = "git+https://github.com/Entropy1729/snarkVM.git#dce9afde31341f382423ee41991dea748d8ad086"
 dependencies = [
  "anyhow",
  "itertools",
@@ -2098,7 +2098,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network-environment"
 version = "0.9.0"
-source = "git+https://github.com/Entropy1729/snarkVM.git#2c4e282df46ed71c809fd4b49738fd78562354ac"
+source = "git+https://github.com/Entropy1729/snarkVM.git#dce9afde31341f382423ee41991dea748d8ad086"
 dependencies = [
  "anyhow",
  "bech32",
@@ -2115,7 +2115,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-program"
 version = "0.9.0"
-source = "git+https://github.com/Entropy1729/snarkVM.git#2c4e282df46ed71c809fd4b49738fd78562354ac"
+source = "git+https://github.com/Entropy1729/snarkVM.git#dce9afde31341f382423ee41991dea748d8ad086"
 dependencies = [
  "enum_index",
  "enum_index_derive",
@@ -2132,7 +2132,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types"
 version = "0.9.0"
-source = "git+https://github.com/Entropy1729/snarkVM.git#2c4e282df46ed71c809fd4b49738fd78562354ac"
+source = "git+https://github.com/Entropy1729/snarkVM.git#dce9afde31341f382423ee41991dea748d8ad086"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-address",
@@ -2147,7 +2147,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-address"
 version = "0.9.0"
-source = "git+https://github.com/Entropy1729/snarkVM.git#2c4e282df46ed71c809fd4b49738fd78562354ac"
+source = "git+https://github.com/Entropy1729/snarkVM.git#dce9afde31341f382423ee41991dea748d8ad086"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -2158,7 +2158,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-boolean"
 version = "0.9.0"
-source = "git+https://github.com/Entropy1729/snarkVM.git#2c4e282df46ed71c809fd4b49738fd78562354ac"
+source = "git+https://github.com/Entropy1729/snarkVM.git#dce9afde31341f382423ee41991dea748d8ad086"
 dependencies = [
  "snarkvm-console-network-environment",
 ]
@@ -2166,7 +2166,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-field"
 version = "0.9.0"
-source = "git+https://github.com/Entropy1729/snarkVM.git#2c4e282df46ed71c809fd4b49738fd78562354ac"
+source = "git+https://github.com/Entropy1729/snarkVM.git#dce9afde31341f382423ee41991dea748d8ad086"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -2175,7 +2175,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-group"
 version = "0.9.0"
-source = "git+https://github.com/Entropy1729/snarkVM.git#2c4e282df46ed71c809fd4b49738fd78562354ac"
+source = "git+https://github.com/Entropy1729/snarkVM.git#dce9afde31341f382423ee41991dea748d8ad086"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -2186,7 +2186,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-integers"
 version = "0.9.0"
-source = "git+https://github.com/Entropy1729/snarkVM.git#2c4e282df46ed71c809fd4b49738fd78562354ac"
+source = "git+https://github.com/Entropy1729/snarkVM.git#dce9afde31341f382423ee41991dea748d8ad086"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -2196,7 +2196,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-scalar"
 version = "0.9.0"
-source = "git+https://github.com/Entropy1729/snarkVM.git#2c4e282df46ed71c809fd4b49738fd78562354ac"
+source = "git+https://github.com/Entropy1729/snarkVM.git#dce9afde31341f382423ee41991dea748d8ad086"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -2206,7 +2206,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-string"
 version = "0.9.0"
-source = "git+https://github.com/Entropy1729/snarkVM.git#2c4e282df46ed71c809fd4b49738fd78562354ac"
+source = "git+https://github.com/Entropy1729/snarkVM.git#dce9afde31341f382423ee41991dea748d8ad086"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -2217,7 +2217,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-curves"
 version = "0.9.0"
-source = "git+https://github.com/Entropy1729/snarkVM.git#2c4e282df46ed71c809fd4b49738fd78562354ac"
+source = "git+https://github.com/Entropy1729/snarkVM.git#dce9afde31341f382423ee41991dea748d8ad086"
 dependencies = [
  "rand",
  "rustc_version",
@@ -2230,7 +2230,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-fields"
 version = "0.9.0"
-source = "git+https://github.com/Entropy1729/snarkVM.git#2c4e282df46ed71c809fd4b49738fd78562354ac"
+source = "git+https://github.com/Entropy1729/snarkVM.git#dce9afde31341f382423ee41991dea748d8ad086"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -2247,7 +2247,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-parameters"
 version = "0.9.0"
-source = "git+https://github.com/Entropy1729/snarkVM.git#2c4e282df46ed71c809fd4b49738fd78562354ac"
+source = "git+https://github.com/Entropy1729/snarkVM.git#dce9afde31341f382423ee41991dea748d8ad086"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -2270,7 +2270,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-r1cs"
 version = "0.9.0"
-source = "git+https://github.com/Entropy1729/snarkVM.git#2c4e282df46ed71c809fd4b49738fd78562354ac"
+source = "git+https://github.com/Entropy1729/snarkVM.git#dce9afde31341f382423ee41991dea748d8ad086"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -2286,7 +2286,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-rest"
 version = "0.9.0"
-source = "git+https://github.com/Entropy1729/snarkVM.git#2c4e282df46ed71c809fd4b49738fd78562354ac"
+source = "git+https://github.com/Entropy1729/snarkVM.git#dce9afde31341f382423ee41991dea748d8ad086"
 dependencies = [
  "anyhow",
  "http",
@@ -2305,7 +2305,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities"
 version = "0.9.0"
-source = "git+https://github.com/Entropy1729/snarkVM.git#2c4e282df46ed71c809fd4b49738fd78562354ac"
+source = "git+https://github.com/Entropy1729/snarkVM.git#dce9afde31341f382423ee41991dea748d8ad086"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -2323,7 +2323,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities-derives"
 version = "0.9.0"
-source = "git+https://github.com/Entropy1729/snarkVM.git#2c4e282df46ed71c809fd4b49738fd78562354ac"
+source = "git+https://github.com/Entropy1729/snarkVM.git#dce9afde31341f382423ee41991dea748d8ad086"
 dependencies = [
  "proc-macro2 1.0.47",
  "quote 1.0.21",
@@ -2333,7 +2333,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-wasm"
 version = "0.9.0"
-source = "git+https://github.com/Entropy1729/snarkVM.git#2c4e282df46ed71c809fd4b49738fd78562354ac"
+source = "git+https://github.com/Entropy1729/snarkVM.git#dce9afde31341f382423ee41991dea748d8ad086"
 dependencies = [
  "getrandom",
  "rand",

--- a/rust/account/src/account.rs
+++ b/rust/account/src/account.rs
@@ -25,6 +25,8 @@ use snarkvm_wasm::{
     program::{Ciphertext as AleoCiphertext, Plaintext as AleoPlaintext, Record as AleoRecord},
 };
 
+pub use snarkvm_wasm::{Block as AleoBlock, Transaction as AleoTransaction, Transactions as AleoTransactions};
+
 pub use snarkvm_wasm::{network::Environment, FromBytes, PrimeField, ToBytes};
 
 pub type CurrentNetwork = Testnet3;
@@ -36,3 +38,6 @@ pub type ViewKey = AleoViewKey<CurrentNetwork>;
 
 pub type Record = AleoRecord<CurrentNetwork, AleoPlaintext<CurrentNetwork>>;
 pub type Ciphertext = AleoRecord<CurrentNetwork, AleoCiphertext<CurrentNetwork>>;
+pub type Block = AleoBlock<CurrentNetwork>;
+pub type Transaction = AleoTransaction<CurrentNetwork>;
+pub type Transactions = AleoTransactions<CurrentNetwork>;

--- a/wasm/src/account/block.rs
+++ b/wasm/src/account/block.rs
@@ -1,0 +1,44 @@
+// Copyright (C) 2019-2021 Aleo Systems Inc.
+// This file is part of the Aleo library.
+
+// The Aleo library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// The Aleo library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with the Aleo library. If not, see <https://www.gnu.org/licenses/>.
+
+use std::str::FromStr;
+
+use aleo_account::Block as BlockNative;
+use wasm_bindgen::prelude::*;
+
+#[wasm_bindgen]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Block(BlockNative);
+
+#[wasm_bindgen]
+impl Block {
+    pub fn from_string(block: &str) -> Self {
+        Self::from_str(block).unwrap()
+    }
+
+    #[allow(clippy::inherent_to_string_shadow_display)]
+    pub fn to_string(&self) -> String {
+        self.0.to_string()
+    }
+}
+
+impl FromStr for Block {
+    type Err = anyhow::Error;
+
+    fn from_str(block: &str) -> Result<Self, Self::Err> {
+        Ok(Self(BlockNative::from_str(block)?))
+    }
+}

--- a/wasm/src/account/ciphertext.rs
+++ b/wasm/src/account/ciphertext.rs
@@ -1,0 +1,44 @@
+// Copyright (C) 2019-2021 Aleo Systems Inc.
+// This file is part of the Aleo library.
+
+// The Aleo library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// The Aleo library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with the Aleo library. If not, see <https://www.gnu.org/licenses/>.
+
+use std::str::FromStr;
+
+use aleo_account::Ciphertext as CiphertextNative;
+use wasm_bindgen::prelude::*;
+
+#[wasm_bindgen]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Ciphertext(CiphertextNative);
+
+#[wasm_bindgen]
+impl Ciphertext {
+    pub fn from_string(ciphertext: &str) -> Self {
+        Self::from_str(ciphertext).unwrap()
+    }
+
+    #[allow(clippy::inherent_to_string_shadow_display)]
+    pub fn to_string(&self) -> String {
+        self.0.to_string()
+    }
+}
+
+impl FromStr for Ciphertext {
+    type Err = anyhow::Error;
+
+    fn from_str(ciphertext: &str) -> Result<Self, Self::Err> {
+        Ok(Self(CiphertextNative::from_str(ciphertext)?))
+    }
+}

--- a/wasm/src/account/mod.rs
+++ b/wasm/src/account/mod.rs
@@ -28,3 +28,12 @@ pub use view_key::*;
 
 pub mod record;
 pub use record::*;
+
+pub mod block;
+pub use block::*;
+
+pub mod transaction;
+pub use transaction::*;
+
+pub mod ciphertext;
+pub use ciphertext::*;

--- a/wasm/src/account/transaction.rs
+++ b/wasm/src/account/transaction.rs
@@ -1,0 +1,68 @@
+// Copyright (C) 2019-2021 Aleo Systems Inc.
+// This file is part of the Aleo library.
+
+// The Aleo library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// The Aleo library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with the Aleo library. If not, see <https://www.gnu.org/licenses/>.
+
+use std::str::FromStr;
+
+use aleo_account::{Transaction as TransactionNative, Transactions as TransactionsNative};
+use wasm_bindgen::prelude::*;
+
+#[wasm_bindgen]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Transaction(TransactionNative);
+
+#[wasm_bindgen]
+impl Transaction {
+    pub fn from_string(transaction: &str) -> Self {
+        Self::from_str(transaction).unwrap()
+    }
+
+    #[allow(clippy::inherent_to_string_shadow_display)]
+    pub fn to_string(&self) -> String {
+        self.0.to_string()
+    }
+}
+
+impl FromStr for Transaction {
+    type Err = anyhow::Error;
+
+    fn from_str(transaction: &str) -> Result<Self, Self::Err> {
+        Ok(Self(TransactionNative::from_str(transaction)?))
+    }
+}
+
+#[wasm_bindgen]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Transactions(TransactionsNative);
+
+#[wasm_bindgen]
+impl Transactions {
+    pub fn from_string(transactions: &str) -> Self {
+        Self::from_str(transactions).unwrap()
+    }
+
+    #[allow(clippy::inherent_to_string_shadow_display)]
+    pub fn to_string(&self) -> String {
+        self.0.to_string()
+    }
+}
+
+impl FromStr for Transactions {
+    type Err = anyhow::Error;
+
+    fn from_str(transactions: &str) -> Result<Self, Self::Err> {
+        Ok(Self(TransactionsNative::from_str(transactions)?))
+    }
+}


### PR DESCRIPTION
## Motivation

It would be useful to have Block and Transaction structs available in the wasm module. This allows us to use this structs directly on any other library that use this wasm package.

To test and use this changes, you must change the `snarkVM` dependency inside the `Cargo.toml` located in the root of the project, and the one located in `rust/account`. Use the branch `snarkvm_wasm_update` until merge.
